### PR TITLE
fix: enforce USD-only invoice currency

### DIFF
--- a/apps/web/src/actions/invoices.ts
+++ b/apps/web/src/actions/invoices.ts
@@ -4,11 +4,15 @@ import { z } from "zod";
 
 import { InvoiceStatus, Prisma, prisma } from "@invoice/db";
 import { requireUser } from "@/lib/auth";
+import { calculateLineTotal, hasAtMostTwoDecimalPlaces } from "@/lib/currency";
 
 const invoiceItemSchema = z.object({
   description: z.string().min(2).max(240),
   quantity: z.coerce.number().positive(),
-  unitPrice: z.coerce.number().nonnegative(),
+  unitPrice: z.coerce
+    .number()
+    .nonnegative()
+    .refine(hasAtMostTwoDecimalPlaces, "Unit price must be a USD amount with cents precision."),
 });
 
 const invoiceSchema = z.object({
@@ -71,7 +75,7 @@ export const createInvoiceAction = async (
             description: item.description,
             quantity: toDecimal(item.quantity),
             unitPrice: toDecimal(item.unitPrice),
-            lineTotal: toDecimal(item.quantity * item.unitPrice),
+            lineTotal: toDecimal(calculateLineTotal(item.quantity, item.unitPrice)),
             position: index + 1,
           })),
         },
@@ -133,7 +137,7 @@ export const updateInvoiceAction = async (
         description: item.description,
         quantity: toDecimal(item.quantity),
         unitPrice: toDecimal(item.unitPrice),
-        lineTotal: toDecimal(item.quantity * item.unitPrice),
+        lineTotal: toDecimal(calculateLineTotal(item.quantity, item.unitPrice)),
         position: index + 1,
       })),
     });

--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -7,7 +7,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { formatCurrency, formatDate } from "@/lib/format";
+import { calculateInvoiceTotal, formatCurrency, INVOICE_CURRENCY_LABEL } from "@/lib/currency";
+import { formatDate } from "@/lib/format";
 import { requireUser } from "@/lib/auth";
 
 export default async function DashboardPage() {
@@ -24,9 +25,8 @@ export default async function DashboardPage() {
   });
 
   const enrichedInvoices = invoices.map((invoice) => {
-    const total = invoice.items.reduce(
-      (sum, item) => sum + Number(item.lineTotal),
-      0,
+    const total = calculateInvoiceTotal(
+      invoice.items.map((item) => ({ lineTotal: Number(item.lineTotal) })),
     );
     return { ...invoice, total };
   });
@@ -116,7 +116,7 @@ export default async function DashboardPage() {
                       <TableRow>
                         <TableHead>Invoice</TableHead>
                         <TableHead>Date</TableHead>
-                        <TableHead>Amount</TableHead>
+                        <TableHead>Amount ({INVOICE_CURRENCY_LABEL})</TableHead>
                         <TableHead>Status</TableHead>
                         <TableHead />
                       </TableRow>

--- a/apps/web/src/app/api/invoices/[invoiceId]/pdf/route.ts
+++ b/apps/web/src/app/api/invoices/[invoiceId]/pdf/route.ts
@@ -5,7 +5,7 @@ import { renderToBuffer } from "@react-pdf/renderer";
 import { auth } from "@/auth";
 import { prisma } from "@invoice/db";
 import { renderInvoicePdf } from "@/lib/pdf/invoice-pdf";
-import { formatCurrency } from "@/lib/format";
+import { calculateInvoiceTotal, formatCurrency } from "@/lib/currency";
 
 const sanitizeFilename = (value: string) =>
   value
@@ -36,9 +36,8 @@ export const GET = async (
     return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
   }
 
-  const total = invoice.items.reduce(
-    (sum, item) => sum + Number(item.lineTotal),
-    0,
+  const total = calculateInvoiceTotal(
+    invoice.items.map((item) => ({ lineTotal: Number(item.lineTotal) })),
   );
 
   const invoiceNumber = invoice.number.toString().padStart(3, "0");

--- a/apps/web/src/components/invoices/invoice-form.tsx
+++ b/apps/web/src/components/invoices/invoice-form.tsx
@@ -13,7 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { formatCurrency } from "@/lib/format";
+import { INVOICE_CURRENCY_LABEL, calculateLineTotal, formatCurrency } from "@/lib/currency";
 import type { FormSubmitEvent } from "@/types/form";
 
 type ClientOption = {
@@ -93,7 +93,7 @@ export const InvoiceForm = ({ clients, defaults, invoice }: InvoiceFormProps) =>
   const total = useMemo(
     () =>
       items.reduce(
-        (sum, item) => sum + item.quantity * item.unitPrice,
+        (sum, item) => sum + calculateLineTotal(item.quantity, item.unitPrice),
         0,
       ),
     [items],
@@ -368,7 +368,7 @@ export const InvoiceForm = ({ clients, defaults, invoice }: InvoiceFormProps) =>
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label>Unit price</Label>
+                  <Label>Unit price ({INVOICE_CURRENCY_LABEL})</Label>
                   <Input
                     type="number"
                     min="0"
@@ -382,7 +382,7 @@ export const InvoiceForm = ({ clients, defaults, invoice }: InvoiceFormProps) =>
                 </div>
                 <div className="flex items-end justify-between gap-3">
                   <div className="text-sm font-medium text-slate-600 dark:text-slate-300">
-                    {formatCurrency(item.quantity * item.unitPrice)}
+                    {formatCurrency(calculateLineTotal(item.quantity, item.unitPrice))}
                   </div>
                   {items.length > 1 ? (
                     <Button
@@ -399,7 +399,7 @@ export const InvoiceForm = ({ clients, defaults, invoice }: InvoiceFormProps) =>
             ))}
           </div>
           <div className="flex items-center justify-end text-lg font-semibold">
-            Total: {formatCurrency(total)}
+            Total ({INVOICE_CURRENCY_LABEL}): {formatCurrency(total)}
           </div>
         </CardContent>
       </Card>

--- a/apps/web/src/lib/__tests__/format.test.ts
+++ b/apps/web/src/lib/__tests__/format.test.ts
@@ -1,10 +1,38 @@
-import { formatCurrency, formatDate } from "@/lib/format";
+import {
+  calculateInvoiceTotal,
+  calculateLineTotal,
+  formatCurrency,
+  hasAtMostTwoDecimalPlaces,
+  INVOICE_CURRENCY,
+} from "@/lib/currency";
+import { formatDate } from "@/lib/format";
 
 describe("format helpers", () => {
-  it("formats currency with USD symbol", () => {
+  it("formats currency as USD", () => {
     const result = formatCurrency(1234.56);
-    expect(result).toContain("$");
-    expect(result).toContain("1,234");
+
+    expect(INVOICE_CURRENCY).toBe("USD");
+    expect(result).toBe("$1,234.56");
+  });
+
+  it("rounds invoice line totals to USD cents", () => {
+    expect(calculateLineTotal(3, 19.995)).toBe(59.99);
+    expect(calculateLineTotal(2, 10.125)).toBe(20.25);
+  });
+
+  it("calculates invoice totals from USD line totals", () => {
+    expect(
+      calculateInvoiceTotal([
+        { lineTotal: 25.5 },
+        { quantity: 2, unitPrice: 19.99 },
+      ]),
+    ).toBe(65.48);
+  });
+
+  it("validates USD cents precision", () => {
+    expect(hasAtMostTwoDecimalPlaces(12.34)).toBe(true);
+    expect(hasAtMostTwoDecimalPlaces(12.345)).toBe(false);
+    expect(hasAtMostTwoDecimalPlaces(Number.NaN)).toBe(false);
   });
 
   it("formats dates in a human readable format", () => {

--- a/apps/web/src/lib/currency.ts
+++ b/apps/web/src/lib/currency.ts
@@ -1,0 +1,28 @@
+export const INVOICE_CURRENCY = "USD" as const;
+export const INVOICE_CURRENCY_LABEL = "USD";
+
+const usdFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: INVOICE_CURRENCY,
+});
+
+export const formatCurrency = (value: number) => usdFormatter.format(value);
+
+export const hasAtMostTwoDecimalPlaces = (value: number) =>
+  Number.isFinite(value) && Number.isInteger(value * 100);
+
+export const calculateLineTotal = (quantity: number, unitPrice: number) =>
+  Math.round(quantity * unitPrice * 100) / 100;
+
+export const calculateInvoiceTotal = (
+  items: Array<{ lineTotal?: number; quantity?: number; unitPrice?: number }>,
+) =>
+  Math.round(
+    items.reduce((sum, item) => {
+      if (typeof item.lineTotal === "number") {
+        return sum + item.lineTotal;
+      }
+
+      return sum + calculateLineTotal(item.quantity ?? 0, item.unitPrice ?? 0);
+    }, 0) * 100,
+  ) / 100;

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -1,8 +1,4 @@
-export const formatCurrency = (value: number) =>
-  new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(value);
+export { formatCurrency, INVOICE_CURRENCY, INVOICE_CURRENCY_LABEL } from "./currency";
 
 export const formatDate = (value: Date) =>
   new Intl.DateTimeFormat("en-US", {

--- a/apps/web/src/lib/pdf/invoice-pdf.tsx
+++ b/apps/web/src/lib/pdf/invoice-pdf.tsx
@@ -7,6 +7,7 @@ import {
   View,
 } from "@react-pdf/renderer";
 import type { ReactElement } from "react";
+import { formatCurrency, INVOICE_CURRENCY_LABEL } from "@/lib/currency";
 
 type InvoicePdfItem = {
   description: string;
@@ -113,6 +114,8 @@ export const renderInvoicePdf = (
           <Text>{data.dueDate}</Text>
           <Text style={styles.label}>Status</Text>
           <Text>{data.status}</Text>
+          <Text style={styles.label}>Currency</Text>
+          <Text>{INVOICE_CURRENCY_LABEL}</Text>
         </View>
       </View>
 
@@ -139,15 +142,15 @@ export const renderInvoicePdf = (
         <View style={styles.tableHeader}>
           <Text style={styles.colDescription}>Description</Text>
           <Text style={styles.colQty}>Qty</Text>
-          <Text style={styles.colPrice}>Price</Text>
-          <Text style={styles.colTotal}>Total</Text>
+          <Text style={styles.colPrice}>Price ({INVOICE_CURRENCY_LABEL})</Text>
+          <Text style={styles.colTotal}>Total ({INVOICE_CURRENCY_LABEL})</Text>
         </View>
         {data.items.map((item, index) => (
           <View key={`${item.description}-${index}`} style={styles.tableRow}>
             <Text style={styles.colDescription}>{item.description}</Text>
             <Text style={styles.colQty}>{item.quantity}</Text>
-            <Text style={styles.colPrice}>{item.unitPrice.toFixed(2)}</Text>
-            <Text style={styles.colTotal}>{item.lineTotal.toFixed(2)}</Text>
+            <Text style={styles.colPrice}>{formatCurrency(item.unitPrice)}</Text>
+            <Text style={styles.colTotal}>{formatCurrency(item.lineTotal)}</Text>
           </View>
         ))}
         <View style={styles.totalRow}>


### PR DESCRIPTION
## Summary
- Centralize invoice currency constants/formatting around USD.
- Use shared USD helpers for form, dashboard, PDF totals, and line totals.
- Validate unit prices to USD cents precision and add regression coverage.

## Milestone
M4 - Invoice Tracking Workflows

## Linked GitHub Issues
Closes #26

## Linked Linear Issues
CE-209

## Validation
- `corepack pnpm --filter @invoice/db db:generate`
- `corepack pnpm --filter web test`
- `corepack pnpm --filter web lint`
- `corepack pnpm --filter web typecheck`
- `corepack pnpm --filter web build`

## Metadata note
I do not have permission to apply upstream labels, milestone, assignee, or project membership from this fork PR. The intended metadata is:
- Milestone: `M4 - Invoice Tracking Workflows`
- Labels: `type/task`, `area/invoices`, `area/product`, `effort/S`
- Assignee: `realkoreanbeef`
- Project: `Invoice Scope Roadmap`

/claim #26